### PR TITLE
Add ensureNotAuthenticated to the code

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-clisk": "^0.17.0",
-    "date-fns": "2.30.0"
+    "date-fns": "2.30.0",
+    "p-wait-for": "^5.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { ContentScript } from 'cozy-clisk/dist/contentscript'
 import Minilog from '@cozy/minilog'
+import waitFor, { TimeoutError } from 'p-wait-for'
 const log = Minilog('ContentScript')
 Minilog.enable('veoliaeauCCC')
 
@@ -346,12 +347,22 @@ class TemplateContentScript extends ContentScript {
 
   async checkBillsPage(testUrl) {
     this.log('debug', 'Starting checkBillsPage')
-    const locationUrl = document.location.href
-    const billsTable = document.querySelector('table')
-    if (locationUrl === testUrl && billsTable) {
-      return true
-    }
-    return false
+
+    await waitFor(
+      () => {
+        const locationUrl = document.location.href
+        const billsTable = document.querySelector('table')
+        return locationUrl === testUrl && Boolean(billsTable)
+      },
+      {
+        interval: 1000,
+        timeout: {
+          milliseconds: 30000,
+          message: new TimeoutError(`checkBillsPage timed out after 30000ms`)
+        }
+      }
+    )
+    return true
   }
 
   async checkBillsTableLength() {

--- a/src/index.js
+++ b/src/index.js
@@ -14,26 +14,39 @@ class TemplateContentScript extends ContentScript {
   // ////////
   async ensureAuthenticated() {
     this.log('debug', 'Starting ensureAuthenticated')
-    const credentials = await this.getCredentials()
-    if (credentials) {
-      const auth = await this.authWithCredentials(credentials)
-      if (auth) {
+    await this.goto(BASE_URL)
+    await this.waitForElementInWorker('.inside-space')
+    await this.ensureNotAuthenticated()
+    const authenticated = await this.runInWorker('checkAuthenticated')
+    if (!authenticated) {
+      this.log('info', 'Not authenticated')
+      const credentials = await this.getCredentials()
+      if (credentials) {
+        await this.authWithCredentials(credentials)
         return true
       }
-      return false
+      await this.authWithoutCredentials()
     }
-    if (!credentials) {
-      const auth = await this.authWithoutCredentials()
-      if (auth) {
-        return true
-      }
-      return false
+    return true
+  }
+
+  async ensureNotAuthenticated() {
+    this.log('debug', 'Starting ensureNOTAuthenticated')
+    const authenticated = await this.runInWorker('checkAuthenticated')
+    if (!authenticated) {
+      this.log('debug', 'Not auth, returning true')
+      return true
     }
+    this.log('debug', 'Seems like already logged, logging out')
+    await this.clickAndWait(
+      'input[value="Déconnexion"]',
+      '#loginBoxform_identification'
+    )
+    return true
   }
 
   async authWithCredentials(credentials) {
     this.log('debug', 'Starting authWithCredentials')
-    await this.goto(BASE_URL)
     await this.waitForElementInWorker('.block-bottom-area')
     const isLogged = await this.runInWorker('checkIfLogged')
     if (isLogged) {
@@ -54,7 +67,6 @@ class TemplateContentScript extends ContentScript {
 
   async authWithoutCredentials() {
     this.log('debug', 'Starting authWithoutCredentials')
-    await this.goto(BASE_URL)
     await this.waitForElementInWorker('#veolia_username')
     await this.waitForUserAuthentication()
   }
@@ -150,6 +162,10 @@ class TemplateContentScript extends ContentScript {
     }
     await this.waitForElementInWorker(selectors.captchaButton)
     await this.runInWorker('handleForm', { selectors, credentials })
+    await this.runInWorkerUntilTrue({
+      method: 'checkRecaptcha',
+      args: [selectors]
+    })
     await this.waitForElementInWorker(
       'a[href="/home/espace-client/vos-factures-et-correspondances.html"]'
     )
@@ -164,7 +180,12 @@ class TemplateContentScript extends ContentScript {
     this.log('debug', 'Starting checkAuthenticated')
     const loginField = document.querySelector('#veolia_username')
     const passwordField = document.querySelector('#veolia_password')
-    if (loginField && passwordField) {
+    if (
+      loginField &&
+      passwordField &&
+      loginField.value !== 'Votre adresse mail' &&
+      passwordField.value !== 'Identifiant'
+    ) {
       const userCredentials = await this.findAndSendCredentials.bind(this)(
         loginField,
         passwordField
@@ -179,6 +200,10 @@ class TemplateContentScript extends ContentScript {
       document.querySelector('.block-deconnecte')
     ) {
       this.log('debug', 'Auth Check succeeded')
+      return true
+    }
+    if (document.querySelector('input[value="Déconnexion"]')) {
+      this.log('debug', 'Detect active session')
       return true
     }
     this.log('debug', 'Not respecting condition, returning false')
@@ -217,29 +242,26 @@ class TemplateContentScript extends ContentScript {
     const captchaButton = document.querySelector(
       loginData.selectors.captchaButton
     )
-    const submitButton = document
-      .querySelector(loginData.selectors.loginForm)
-      .querySelector(loginData.selectors.loginButton)
-    captchaButton.click()
-    await this.checkRecaptcha()
     loginElement.value = loginData.credentials.login
     passwordElement.value = loginData.credentials.password
-    submitButton.click()
+    captchaButton.click()
   }
 
-  async checkRecaptcha() {
+  async checkRecaptcha(selectors) {
     this.log('debug', 'Starting checkRecaptcha')
     let captchaValue = document.querySelector(
       'input[name="frc-captcha-solution"]'
     ).value
-    while (captchaValue.length < 100) {
+    if (captchaValue.length < 100) {
       this.log('debug', 'Recaptcha is not finished')
-      await sleep(3)
-      captchaValue = document.querySelector(
-        'input[name="frc-captcha-solution"]'
-      ).value
+      return false
+    } else {
+      const submitButton = document
+        .querySelector(selectors.loginForm)
+        .querySelector(selectors.loginButton)
+      submitButton.click()
+      return true
     }
-    return true
   }
 
   async getUserPersonalInfos() {
@@ -431,15 +453,17 @@ connector
       'getDocuments',
       'checkMoreBillsButton',
       'checkBillsTableLength',
-      'checkBillsPage'
+      'checkBillsPage',
+      'checkRecaptcha'
     ]
   })
   .catch(err => {
     log.warn(err)
   })
 
-function sleep(delay) {
-  return new Promise(resolve => {
-    setTimeout(resolve, delay * 1000)
-  })
-}
+// Keep this here for debugging purpose
+// function sleep(delay) {
+//   return new Promise(resolve => {
+//     setTimeout(resolve, delay * 1000)
+//   })
+// }

--- a/src/index.js
+++ b/src/index.js
@@ -134,12 +134,12 @@ class TemplateContentScript extends ContentScript {
       this.saveIdentity(this.store.userIdentity),
       this.saveFiles(this.store.files, {
         context,
-        fileIdAttributes: ['filename'],
+        fileIdAttributes: ['vendorRef'],
         contentType: 'application/pdf'
       }),
       this.saveBills(this.store.bills, {
         context,
-        fileIdAttributes: ['filename'],
+        fileIdAttributes: ['vendorRef'],
         contentType: 'application/pdf',
         qualificationLabel: 'water_invoice'
       })
@@ -368,8 +368,10 @@ class TemplateContentScript extends ContentScript {
       const extractedDatas = await this.extractDatas(document)
       const computedFile = await this.computeDatas(extractedDatas)
       if (computedFile.documentType === 'Facture') {
+        computedFile.vendorRef = `${computedFile.vendorRef}-F`
         bills.push(computedFile)
       } else {
+        computedFile.vendorRef = `${computedFile.vendorRef}-C`
         files.push(computedFile)
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ class TemplateContentScript extends ContentScript {
 
   async ensureNotAuthenticated() {
     this.log('debug', 'Starting ensureNOTAuthenticated')
+    await this.goto(BASE_URL)
     const authenticated = await this.runInWorker('checkAuthenticated')
     if (!authenticated) {
       this.log('debug', 'Not auth, returning true')

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,6 @@ class TemplateContentScript extends ContentScript {
     this.log('debug', 'Starting ensureAuthenticated')
     await this.goto(BASE_URL)
     await this.waitForElementInWorker('.inside-space')
-    await this.ensureNotAuthenticated()
     const authenticated = await this.runInWorker('checkAuthenticated')
     if (!authenticated) {
       this.log('info', 'Not authenticated')
@@ -27,12 +26,20 @@ class TemplateContentScript extends ContentScript {
       }
       await this.authWithoutCredentials()
     }
+    await this.runInWorker('click', 'a[href="/home/espace-client.html"]')
+    await this.waitForElementInWorker(
+      'a[href="/home/espace-client/vos-contrats.html"]'
+    )
     return true
   }
 
   async ensureNotAuthenticated() {
-    this.log('debug', 'Starting ensureNOTAuthenticated')
+    this.log('debug', 'Starting ensureNotAuthenticated')
     await this.goto(BASE_URL)
+    await Promise.race([
+      this.waitForElementInWorker('.submitButton'),
+      this.waitForElementInWorker('#veolia_username')
+    ])
     const authenticated = await this.runInWorker('checkAuthenticated')
     if (!authenticated) {
       this.log('debug', 'Not auth, returning true')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,1 @@
-const path = require('path')
-const CopyPlugin = require('copy-webpack-plugin')
-
-module.exports = {
-  mode: 'none',
-  output: {
-    path: path.join(process.cwd(), 'build'),
-    filename: 'main.js'
-  },
-  plugins: [
-    new CopyPlugin({
-      patterns: [{ from: 'manifest.konnector' }, { from: 'assets' }]
-    })
-  ]
-}
+module.exports = require('cozy-konnector-build/webpack.config.clisk')


### PR DESCRIPTION
Regarding a better running of the connectors, we decided to be sure we're logged out from visited websites before fetching anything to avoid possible scenarios where we could have been connected (by cookies or whatever) but not having an account defined in the cozy. This PR is for that reason.

I also modify a bit the autoLogin to get rid of the "sleep" function that can only be used for debbuging and some other minors changes like avoiding saving the placeholders value from the login form.